### PR TITLE
fix(netfilter): prevent duplicate bans from orphaning firewall rules

### DIFF
--- a/data/Dockerfiles/netfilter/main.py
+++ b/data/Dockerfiles/netfilter/main.py
@@ -147,7 +147,7 @@ def ban(address):
   logdebug("Ban net: %s" % net)
 
   if not net in bans:
-    bans[net] = {'attempts': 0, 'last_attempt': 0, 'ban_counter': 0}
+    bans[net] = {'attempts': 0, 'last_attempt': 0, 'ban_counter': 0, 'banned': False}
     logdebug("Initing new ban counter for %s" % net)
 
   current_attempt = time.time()
@@ -162,6 +162,9 @@ def ban(address):
   logdebug("%s attempts now %d" % (net, bans[net]['attempts']))
 
   if bans[net]['attempts'] >= MAX_ATTEMPTS:
+    if bans[net].get('banned'):
+      logdebug("%s is already actively banned -- skipping duplicate ban()" % net)
+      return
     cur_time = int(round(time.time()))
     NET_BAN_TIME = calcNetBanTime(bans[net]['ban_counter'])
     logger.logCrit('Banning %s for %d minutes' % (net, NET_BAN_TIME / 60 ))
@@ -174,6 +177,7 @@ def ban(address):
         logdebug("Calling tables.banIPv6(%s)" % net)
         tables.banIPv6(net)
 
+    bans[net]['banned'] = True
     logdebug("Updating F2B_ACTIVE_BANS[%s]=%d" %
               (net, cur_time + NET_BAN_TIME))
     r.hset('F2B_ACTIVE_BANS', '%s' % net, cur_time + NET_BAN_TIME)
@@ -228,6 +232,7 @@ def unban(net):
     logdebug("Unban for %s, setting attempts=0, ban_counter+=1" % net_str)
     bans[net]['attempts'] = 0
     bans[net]['ban_counter'] += 1
+    bans[net]['banned'] = False
 
 def safe_unban(net, reason=''):
   try:

--- a/data/Dockerfiles/netfilter/modules/NFTables.py
+++ b/data/Dockerfiles/netfilter/modules/NFTables.py
@@ -100,10 +100,18 @@ class NFTables:
         self.logger.logInfo(f"Clear completed: {_family}")
 
   def banIPv4(self, source):
+    # nft insert rule has no dedup: a second ban() call for a net that's
+    # already banned would add a second identical DROP rule, which unban()
+    # (single-match delete) can never fully clear -- an orphaned rule.
+    if self.is_already_banned(source, "ip"):
+      return False
     ban_dict = self.get_ban_ip_dict(source, "ip")
     return self.nft_exec_dict(ban_dict)
 
   def banIPv6(self, source):
+    # See banIPv4() -- same duplicate-insert/orphaned-rule risk applies.
+    if self.is_already_banned(source, "ip6"):
+      return False
     ban_dict = self.get_ban_ip_dict(source, "ip6")
     return self.nft_exec_dict(ban_dict)
 
@@ -436,6 +444,34 @@ class NFTables:
     json_command["nftables"].append(base_dict)
 
     return json_command
+
+  def is_already_banned(self, ipaddr: str, _family: str):
+    _chain_opts = {'family': _family, 'table': 'filter', 'name': self.chain_name}
+    command = self.get_base_dict()
+    command['nftables'].append({'list': {'chain': _chain_opts} })
+    kernel_ruleset = self.nft_exec_dict(command)
+    if not kernel_ruleset:
+      return False
+
+    candidate_net = ipaddress.ip_network(ipaddr, strict=False)
+    for _object in kernel_ruleset["nftables"]:
+      if not _object.get("rule"):
+        continue
+      rule = _object["rule"]["expr"][0]["match"]
+      if not "payload" in rule["left"]:
+        continue
+      left_opt = rule["left"]["payload"]
+      if left_opt["protocol"] != _family or left_opt["field"] != "saddr":
+        continue
+      rule_right = rule["right"]
+      if isinstance(rule_right, dict):
+        current_rule_ip = rule_right["prefix"]["addr"] + '/' + str(rule_right["prefix"]["len"])
+      else:
+        current_rule_ip = rule_right
+      if ipaddress.ip_network(current_rule_ip) == candidate_net:
+        return True
+
+    return False
 
   def get_unban_ip_dict(self, ipaddr:str, _family: str):
     json_command = self.get_base_dict()


### PR DESCRIPTION
Follow-up to what this branch already fixes for #5879.

**What #7120 covers:** `unban()` used to skip cleanup entirely when a net was missing from the in-memory `bans` dict (e.g. after a container restart, since Redis's `F2B_ACTIVE_BANS` persists but `bans` doesn't) — leaving bans stuck forever.

**What's missing:** `ban()` has no guard against re-issuing a ban for a net that's already actively banned — it only gates on an attempt counter that stays satisfied until `unban()` resets it. `NFTables.banIPv4/6()` also has no dedup check before inserting (unlike `IPTables.py`, which already had one), and nftables itself doesn't dedup on insert (confirmed empirically). Since `unbanIPv4/6()` only ever removes one matching rule per call, any double-fire of `ban()` leaves a permanently orphaned DROP rule. Found multiple times of these in production.

**Fix:** adds a `banned` flag to `bans[net]` so `ban()` skips re-issuing an active ban, and adds a small `is_already_banned()` check to `NFTables.py` so `banIPv4/6()` skip inserting if a matching rule already exists.

Built and deployed to production, verified byte-identical in the built image after a save/load round-trip, running clean since deploy - i.e. no zombie iptables rules leftofers.